### PR TITLE
Store speed profile preferences with JMRI configuration profile

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
+++ b/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
@@ -93,7 +93,7 @@ public class RosterSpeedProfile {
      * Returns the scale speed format as a string with the units added given MilliMetres per Second.
      * If the warrant preference  is a percentage of normal or throttle will use metres per second.
      * @param mms MilliMetres per second
-     * @return a string with scale speed & units
+     * @return a string with scale speed and units
      */
     public String convertMMSToScaleSpeedWithUnits(float mms) {
         int interp = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getInterpretation();
@@ -121,7 +121,7 @@ public class RosterSpeedProfile {
      * Returns the scale speed format as a string with the units added given a throttle setting. and direction
      * @param throttleSetting as percentage of 1.0
      * @param isForward true or false
-     * @return a string with scale speed & units
+     * @return a string with scale speed and units
      */
     public String convertThrottleSettingToScaleSpeedWithUnits(float throttleSetting, boolean isForward) {
         return convertMMSToScaleSpeedWithUnits(getSpeed(throttleSetting, isForward));

--- a/java/src/jmri/jmrit/throttle/SpeedPanel.java
+++ b/java/src/jmri/jmrit/throttle/SpeedPanel.java
@@ -9,6 +9,7 @@ import javax.swing.JPanel;
 import javax.swing.WindowConstants;
 import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.jmrit.roster.RosterEntry;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/java/src/jmri/jmrit/throttle/SpeedPanel.java
+++ b/java/src/jmri/jmrit/throttle/SpeedPanel.java
@@ -15,8 +15,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A JInternalFrame that contains a label to display scale speed if available
- * for forward, reverse and STOP.
- * TODO: fix speed increments (14, 28)
+ * for forward, reverse and STOP. TODO: fix speed increments (14, 28)
  *
  * @author glen Copyright (C) 2002
  * @author Bob Jacobsen Copyright (C) 2007
@@ -24,13 +23,14 @@ import org.slf4j.LoggerFactory;
  * @author Steve Gigiel Copyright (C) 2017
  */
 public class SpeedPanel extends JInternalFrame implements java.beans.PropertyChangeListener, AddressListener {
+
     private DccThrottle throttle;
 
     private JPanel mainPanel;
 
     private JPanel speedDisplayPanel;
 
-    private JLabel scaleSpeedLabel  = new JLabel("", JLabel.CENTER);
+    private JLabel scaleSpeedLabel = new JLabel("", JLabel.CENTER);
 
     // tracks whether we are using speed profiles
     private boolean useSpeedProfile = false;
@@ -50,7 +50,9 @@ public class SpeedPanel extends JInternalFrame implements java.beans.PropertyCha
     }
 
     /**
-     * Set the AddressPanel this throttle control is listening for new throttle event
+     * Set the AddressPanel this throttle control is listening for new throttle
+     * event
+     *
      * @param addressPanel - reference to the addresspanel
      */
     public void setAddressPanel(AddressPanel addressPanel) {
@@ -91,16 +93,16 @@ public class SpeedPanel extends JInternalFrame implements java.beans.PropertyCha
     }
 
     /**
-     *  update the state of this panel if direction or speed change
+     * update the state of this panel if direction or speed change
      */
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
         if (e.getPropertyName().equals("SpeedSetting")) {
             currentThrottleVol = ((Float) e.getNewValue()).floatValue();
-            scaleSpeedLabel.setText(updateSpeedLabel(useSpeedProfile,currentThrottleVol,currentIsForward));
+            scaleSpeedLabel.setText(updateSpeedLabel(useSpeedProfile, currentThrottleVol, currentIsForward));
         } else if (e.getPropertyName().equals("IsForward")) {
             currentIsForward = (boolean) e.getNewValue();
-            scaleSpeedLabel.setText(updateSpeedLabel(useSpeedProfile,currentThrottleVol,currentIsForward));
+            scaleSpeedLabel.setText(updateSpeedLabel(useSpeedProfile, currentThrottleVol, currentIsForward));
         }
         if (log.isDebugEnabled()) {
             log.debug("Property change event received " + e.getPropertyName() + " / " + e.getNewValue());
@@ -110,18 +112,20 @@ public class SpeedPanel extends JInternalFrame implements java.beans.PropertyCha
     /**
      *
      * @param useSpeedProfile - are we using speed profile
-     * @param throttleVolume - throttle position (percent of 1)
-     * @param isForward - true if going forward.
+     * @param throttleVolume  - throttle position (percent of 1)
+     * @param isForward       - true if going forward.
      * @return a string for displaying speed if available
      */
     private String updateSpeedLabel(boolean useSpeedProfile, float throttleVolume, boolean isForward) {
-        if (useSpeedProfile) {
-            return(addressPanel.getRosterEntry().getSpeedProfile().convertThrottleSettingToScaleSpeedWithUnits(throttleVolume,isForward));
+        RosterEntry re = addressPanel.getRosterEntry();
+        if (re != null && useSpeedProfile) {
+            return (re.getSpeedProfile().convertThrottleSettingToScaleSpeedWithUnits(throttleVolume, isForward));
         } else {
-            return(Bundle.getMessage("ThrottleSpeedPanelError"));
+            return (Bundle.getMessage("ThrottleSpeedPanelError"));
         }
 
     }
+
     @Override
     public void notifyAddressChosen(LocoAddress l) {
     }
@@ -149,8 +153,10 @@ public class SpeedPanel extends JInternalFrame implements java.beans.PropertyCha
         }
 
         useSpeedProfile = false;  //posit false
-        if (addressPanel.getRosterEntry().getSpeedProfile() != null
-                && addressPanel.getRosterEntry().getSpeedProfile().getProfileSize() > 0) {
+        RosterEntry re = addressPanel.getRosterEntry();
+        if (re != null
+                && re.getSpeedProfile() != null
+                && re.getSpeedProfile().getProfileSize() > 0) {
             useSpeedProfile = true;
         }
     }
@@ -170,9 +176,9 @@ public class SpeedPanel extends JInternalFrame implements java.beans.PropertyCha
         }
         notifyAddressThrottleFound(throttle);
     }
+
     /**
-     * Collect the prefs of this object into XML Element
-     * Just Positional Data
+     * Collect the prefs of this object into XML Element Just Positional Data
      * <ul>
      * <li> Window prefs
      * </ul>
@@ -189,8 +195,7 @@ public class SpeedPanel extends JInternalFrame implements java.beans.PropertyCha
     }
 
     /**
-     * Set the preferences based on the XML Element.
-     * Just positional data
+     * Set the preferences based on the XML Element. Just positional data
      * <ul>
      * <li> Window prefs
      * </ul>


### PR DESCRIPTION
Store the speed profile preferences with the JMRI configuration profile. This eliminates the need to be concerned about file management for storing these preferences.

Also:
- Fix some NPEs observed while testing
- Some whitespace changes (my IDE did this automatically)
- Replace ActionListener anonymous classes with Lambda expressions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pugwash1/jmri/1)
<!-- Reviewable:end -->
